### PR TITLE
Migrate Dart Sass 2.0.0 to Dart Sass 3.0.0

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -1,18 +1,18 @@
 // Mixins
-@import 'mixins/media';
+@use 'mixins/media';
 
 // Configuration
-@import 'config/reset';
-@import 'config/variables';
+@use 'config/reset';
+@use 'config/variables';
 
 // Components
-@import 'components/btn';
-@import 'components/form';
-@import 'components/quote';
-@import 'components/error_message';
-@import 'components/visually_hidden';
-@import 'components/turbo_progress_bar';
+@use 'components/btn';
+@use 'components/form';
+@use 'components/quote';
+@use 'components/error_message';
+@use 'components/visually_hidden';
+@use 'components/turbo_progress_bar';
 
 // Layouts
-@import 'layouts/header';
-@import 'layouts/container';
+@use 'layouts/header';
+@use 'layouts/container';

--- a/app/assets/stylesheets/components/_quote.scss
+++ b/app/assets/stylesheets/components/_quote.scss
@@ -1,3 +1,5 @@
+@use "../mixins/media";
+
 .quote {
   display: flex;
   justify-content: space-between;
@@ -10,7 +12,7 @@
   margin-bottom: var(--space-m);
   padding: var(--space-xs);
 
-  @include media(tabletAndUp) {
+  @include media.media(tabletAndUp) {
     padding: var(--space-xs) var(--space-m);
   }
 

--- a/app/assets/stylesheets/layouts/_container.scss
+++ b/app/assets/stylesheets/layouts/_container.scss
@@ -1,3 +1,5 @@
+@use "../mixins/media";
+
 .container {
   width: 100%;
   padding-right: var(--space-xs);
@@ -5,7 +7,7 @@
   margin-left: auto;
   margin-right: auto;
 
-  @include media(tabletAndUp) {
+  @include media.media(tabletAndUp) {
     padding-right: var(--space-m);
     padding-left: var(--space-m);
     max-width: 60rem;

--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -1,3 +1,5 @@
+@use "../mixins/media";
+
 .header {
   display: flex;
   flex-wrap: wrap;
@@ -6,7 +8,7 @@
   margin-top: var(--space-m);
   margin-bottom: var(--space-l);
 
-  @include media(tabletAndUp) {
+  @include media.media(tabletAndUp) {
     margin-bottom: var(--space-xl);
   }
 }


### PR DESCRIPTION
Migrate Dart Sass 2.0.0 to Dart Sass 3.0.0. Using the upgrade procedure from here: https://sass-lang.com/documentation/breaking-changes/import/